### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/backend/app/enode/webhook.py
+++ b/backend/app/enode/webhook.py
@@ -31,7 +31,8 @@ async def subscribe_to_webhooks():
             "user:vehicle:updated"
         ]
     }
-    print("[📡 ENODE] Subscribing to webhooks with payload:", payload)
+    sanitized_payload = {**payload, "secret": "REDACTED"}
+    print("[📡 ENODE] Subscribing to webhooks with payload:", sanitized_payload)
     
     url = f"{ENODE_BASE_URL}/webhooks"
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
Potential fix for [https://github.com/rogasp/evlink-backend/security/code-scanning/3](https://github.com/rogasp/evlink-backend/security/code-scanning/3)

To fix the issue, we need to ensure that sensitive information such as `ENODE_WEBHOOK_SECRET` is not logged. Instead of logging the entire `payload` object, we can log a sanitized version of it that excludes sensitive fields. This can be achieved by creating a copy of the `payload` object with the sensitive fields redacted or removed before logging. This approach maintains the utility of the log for debugging while protecting sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
