### PR TITLE
Add newsletter endpoints to docs

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -14,6 +14,9 @@ This document describes the available API endpoints in the EVLink backend, group
 | POST   | `/api/confirm-link`     | Accept link token from Enode    |
 | GET    | `/api/public/user/{user_id}` | Check if user exists         |
 | GET    | `/api/public/user/{user_id}/apikey` | Fetch user’s API key (login flow) |
+| POST   | `/api/newsletter/subscribe` | Request to join the newsletter |
+| POST   | `/api/newsletter/unsubscribe` | Remove address from newsletter |
+| GET    | `/api/newsletter/verify` | Confirm newsletter subscription |
 
 ---
 


### PR DESCRIPTION
## Summary
- add newsletter subscribe, unsubscribe and verify endpoints to docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842240aede88322ba6173ee5eec8a05