### PR TITLE
fix: Badge overlap with plan names in multiple languages (Follow-up to #247)

### DIFF
--- a/frontend/src/components/landing/PricingSection.tsx
+++ b/frontend/src/components/landing/PricingSection.tsx
@@ -102,12 +102,12 @@ export default function PricingSection() {
               className={`relative border shadow-md bg-white ${key === 'custom' ? 'bg-muted/50 opacity-60' : ''}`}
             >
               {btn.badge && (
-                <Badge variant="secondary" className="absolute top-4 right-4 z-10">
+                <Badge variant="secondary" className="absolute top-2 right-2 z-10 text-xs">
                   {btn.badge}
                 </Badge>
               )}
-              <CardHeader>
-                <CardTitle className="text-xl font-semibold">{cfg.title}</CardTitle>
+              <CardHeader className="pt-6">
+                <CardTitle className={`text-xl font-semibold uppercase ${btn.badge ? 'mt-1' : ''}`}>{cfg.title}</CardTitle>
                 <div className="mt-2 text-lg text-blue-800 font-bold">{cfg.price}</div>
               </CardHeader>
               <CardContent className="space-y-3">


### PR DESCRIPTION
## Summary

Follow-up fix to Issue #247 - addresses badge overlap with plan names when using longer translated text (e.g., Swedish "Nuvarande Plan").

## Problem

After testing the original fix in multiple languages, discovered that the "Current Plan" badge overlaps with tier names (FREE, BASIC, PRO, CUSTOM) in languages with longer translations.

## Solution

- Move badge closer to corner with smaller text (`top-2 right-2 text-xs`)
- Add minimal top margin (`mt-1`) to CardTitle when badge exists  
- Make plan names uppercase for better visual hierarchy
- Maintain proper spacing without excessive white space

## Changes Made

- Adjusted badge positioning and size in `PricingSection.tsx`
- Added conditional margin to plan titles
- Enhanced typography with uppercase plan names

## Test Plan

- [x] Verify badge doesn't overlap plan names in English
- [x] Verify badge doesn't overlap plan names in Swedish  
- [x] Confirm proper spacing and visual hierarchy
- [x] Test responsive behavior on different screen sizes

This resolves the multi-language compatibility issue discovered after the initial #247 fix.

🤖 Generated with [Claude Code](https://claude.ai/code)